### PR TITLE
fix: ensure RetryError extends Error properly

### DIFF
--- a/libs/js-core/src/retry.ts
+++ b/libs/js-core/src/retry.ts
@@ -16,6 +16,7 @@ export class RetryError extends Error {
   ) {
     super(message);
     this.name = 'RetryError';
+    Object.setPrototypeOf(this, RetryError.prototype);
   }
 }
 


### PR DESCRIPTION
## Summary
- maintain prototype chain for `RetryError` to allow reliable `instanceof` checks

## Testing
- `pnpm tsc` *(fails: Cannot read file '/workspace/Project-Argus/libs/js-core/tsconfig.json')*

------
https://chatgpt.com/codex/tasks/task_e_68acb4c6fbc883319d42e3de3fcff0bd