### PR TITLE
feat(core): introduce plugin framework and session backoff

### DIFF
--- a/apps/scraper-playwright/src/plugins/mapsNetworkTap.ts
+++ b/apps/scraper-playwright/src/plugins/mapsNetworkTap.ts
@@ -1,7 +1,7 @@
 // Intercept GMaps XHR to extract review payloads; emits unified Review[]
 import { EventEmitter } from 'node:events';
 import type { Page } from 'playwright';
-import { Review, normalizeReview } from '@argus/js-core';
+import { Review, normalizeReview, Plugin } from '@argus/js-core';
 
 export interface NetworkTapOptions {
   blockHeavyResources?: boolean;
@@ -66,3 +66,11 @@ export function createNetworkTap(page: Page, emitter: EventEmitter) {
     }
   });
 }
+
+export const networkTapPlugin = (bus: EventEmitter): Plugin => ({
+  name: 'networkTap',
+  init({ page }: { page: Page }) {
+    tap(page, bus);
+  },
+  async run() {},
+});

--- a/apps/scraper-playwright/src/plugins/scroll.ts
+++ b/apps/scraper-playwright/src/plugins/scroll.ts
@@ -1,0 +1,27 @@
+import type { Page } from 'playwright';
+import { Plugin } from '@argus/js-core';
+
+export function scrollPlugin(pause: number, timeout = 12000): Plugin {
+  return {
+    name: 'scroll',
+    async run({ page }: { page: Page }) {
+      await Promise.race([
+        page.evaluate(async (delay) => {
+          await new Promise<void>(resolve => {
+            let total = 0;
+            const step = window.innerHeight;
+            const timer = setInterval(() => {
+              window.scrollBy(0, step);
+              total += step;
+              if (total >= document.body.scrollHeight) {
+                clearInterval(timer);
+                resolve();
+              }
+            }, delay);
+          });
+        }, pause),
+        page.waitForTimeout(timeout)
+      ]);
+    }
+  };
+}

--- a/libs/js-core/src/__tests__/session.test.ts
+++ b/libs/js-core/src/__tests__/session.test.ts
@@ -1,0 +1,22 @@
+import { SessionPool } from '../session';
+
+describe('SessionPool backoff', () => {
+  test('penalize applies exponential delay', () => {
+    const sp = new SessionPool({ size: 1, minScore: 0 });
+    const s = sp.borrow();
+    sp.penalize(s);
+    const firstDelay = s.backoffUntil - Date.now();
+    expect(firstDelay).toBeGreaterThanOrEqual(1000);
+    sp.penalize(s);
+    const secondDelay = s.backoffUntil - Date.now();
+    expect(secondDelay).toBeGreaterThan(firstDelay);
+  });
+
+  test('borrow skips sessions in backoff', () => {
+    const sp = new SessionPool({ size: 2, minScore: 0 });
+    const s1 = sp.borrow();
+    sp.penalize(s1);
+    const s2 = sp.borrow();
+    expect(s2.id).not.toBe(s1.id);
+  });
+});

--- a/libs/js-core/src/index.ts
+++ b/libs/js-core/src/index.ts
@@ -4,4 +4,5 @@ export * from "./session.js";
 export * from "./persist.js";
 export * from "./dataset.js";
 export * from "./errors.js";
+export * from "./plugin.js";
 

--- a/libs/js-core/src/plugin.ts
+++ b/libs/js-core/src/plugin.ts
@@ -1,0 +1,36 @@
+export interface PluginContext {
+  [key: string]: any;
+}
+
+export interface Plugin {
+  name: string;
+  init?(ctx: PluginContext): Promise<void> | void;
+  run(ctx: PluginContext): Promise<void>;
+  teardown?(ctx: PluginContext): Promise<void> | void;
+}
+
+export class PluginManager {
+  private plugins: Plugin[] = [];
+
+  register(plugin: Plugin) {
+    this.plugins.push(plugin);
+  }
+
+  async init(ctx: PluginContext) {
+    for (const p of this.plugins) {
+      if (p.init) await p.init(ctx);
+    }
+  }
+
+  async run(ctx: PluginContext) {
+    for (const p of this.plugins) {
+      await p.run(ctx);
+    }
+  }
+
+  async teardown(ctx: PluginContext) {
+    for (const p of this.plugins) {
+      if (p.teardown) await p.teardown(ctx);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add lightweight plugin interface and manager
- expand session pool with exponential backoff
- wire up scroll and network tap plugins in Playwright scraper

## Testing
- `npx jest` *(fails: Preset ts-jest not found)*
- `node libs/js-core/test-runner.js` *(fails: Cannot find module 'dist/request-queue.js')*

------
https://chatgpt.com/codex/tasks/task_e_68acb4c6fbc883319d42e3de3fcff0bd