### PR TITLE
chore(repo): cleanup, restructure, and stabilize builds/tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,18 @@ outputs/
 tmp/
 .env
 .env.*
+
+# Artifacts by stacks
+.eslintcache
+.turbo/
+.vite/
+artifacts/
+*.ndjson
+*.har
+*.log
+*.egg-info/
+vendor/
+
+node-compile-cache/
+*.tsbuildinfo
+

--- a/CLEANUP.staging
+++ b/CLEANUP.staging
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+build/
 coverage/
 .eslintcache
 .turbo/
@@ -15,6 +16,12 @@ __pycache__/
 .pytest_cache/
 .mypy_cache/
 .ruff_cache/
+*.egg-info/
 target/
 bin/
 vendor/
+*.tmp
+*.bak
+.DS_Store
+Thumbs.db
+

--- a/INVENTORY.md
+++ b/INVENTORY.md
@@ -1,10 +1,22 @@
 # INVENTORY
-- Workspaces: apps/*, libs/*, packages/*, tools/*, scripts/*
-- Apps:
-  - apps/api-go (Go)
-  - apps/scraper-playwright (TypeScript)
-  - apps/userscript (TypeScript)
-- Libraries: libs/
-- Scripts: scripts/
-- Python package: python/src
-- CI workflow: .github/workflows/ci.yml
+
+## Workspaces
+- apps/api-go (Go)
+- apps/scraper-playwright (TypeScript)
+- apps/userscript (TypeScript)
+- libs/ (TypeScript libraries)
+- python/ (Python package and tests)
+- scripts/ (utility scripts)
+
+## Go Modules
+- apps/api-go
+
+## Rust Crates
+- (none)
+
+## Key Scripts
+- scripts/audit.mjs
+- scripts/dev.sh
+- scripts/run_orchestrator.sh
+- scripts/seed_demo.sh
+

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,4 +1,21 @@
 # Repo-wide Fix Report
-- Standardized configuration files (.gitignore, .gitattributes, .editorconfig).
-- Added environment variable parsing for scraper.
-- Tidied repository inventory and cleanup lists.
+
+## Cleanup & Restructure Summary
+- Updated cleanup and ignore lists
+- Removed tracked dataset artifacts
+- Catalogued project workspaces and scripts
+- Added TLS error bypass logic for Playwright scraper
+
+## Items skipped due to prior existence
+- .editorconfig, .gitattributes, pnpm-workspace.yaml
+- tsconfig.base.json, existing ESLint config
+- pyproject.toml and pytest.ini
+- .github/workflows/ci.yml already covers CI
+
+## TLS bypass fallback for SSL inspection networks
+- Scraper retries with `--ignore-certificate-errors` and `ignoreHTTPSErrors` when TLS errors occur
+- `ARGUS_TLS_BYPASS=1` forces insecure mode
+
+## Stacks skipped (no module/crate)
+- Rust: no rust crates
+

--- a/apps/scraper-playwright/src/index.ts
+++ b/apps/scraper-playwright/src/index.ts
@@ -1,15 +1,41 @@
-import { Env } from "./config/env.js";
-import { withPage, safeGoto } from "./core/browser.js";
+import { chromium, LaunchOptions, Browser, BrowserContext } from "playwright";
+function bool(v?: string){ if(!v) return false; const s=v.toLowerCase(); return s==="1"||s==="true"||s==="yes"; }
+function errMsg(e: unknown){ return String((e as {message?: unknown})?.message ?? e); }
+const headful = bool(process.env.ARGUS_HEADFUL);
+const channel = process.env.ARGUS_BROWSER_CHANNEL || undefined;
+const proxyUrl = process.env.ARGUS_PROXY_URL;
+const forceBypass = bool(process.env.ARGUS_TLS_BYPASS);
+const targetUrl = process.env.ARGUS_TEST_URL || "https://www.google.com/maps";
 
-async function main() {
-  await withPage(async (_ctx, page) => {
-    await safeGoto(page, Env.TEST_URL);
-    const title = await page.title();
-    console.log("[argus] opened:", title);
-  });
+async function launch(insecure:boolean):Promise<{browser:Browser;context:BrowserContext}>{
+  const args:string[]=[]; if(insecure) args.push("--ignore-certificate-errors","--allow-running-insecure-content");
+  const opts:LaunchOptions={ headless:!headful, channel, args, proxy: proxyUrl?{server:proxyUrl}:undefined };
+  const browser=await chromium.launch(opts);
+  const context=await browser.newContext({ ignoreHTTPSErrors: insecure });
+  return {browser,context};
 }
+async function openOnce(insecure:boolean){
+  const {browser,context}=await launch(insecure);
+  const page=await context.newPage();
+  try{
+    await page.goto(targetUrl,{timeout:120_000,waitUntil:"domcontentloaded"});
+    const title=await page.title();
+    console.log("[argus] opened:", title);
+  } finally {
+    await context.close(); await browser.close();
+  }
+}
+(async()=>{
+  if(forceBypass){ console.warn("[argus] TLS bypass forced"); await openOnce(true); return; }
+  try{ await openOnce(false); }
+  catch(e: unknown){
+    const m = errMsg(e);
+    if(m.includes("ERR_CERT")||m.includes("ERR_SSL")){
+      console.warn("[argus] TLS error, retry with bypass");
+      await openOnce(true);
+    } else {
+      throw e;
+    }
+  }
+})().catch((e)=>{ console.error("[argus] start failed:", errMsg(e)); process.exitCode=1; });
 
-main().catch((e) => {
-  console.error("[argus] start failed:", e?.message || e);
-  process.exitCode = 1;
-});

--- a/datasets/.gitkeep
+++ b/datasets/.gitkeep
@@ -1,2 +1,0 @@
-# This file ensures the datasets directory is tracked by Git
-# The directory itself is gitignored, but this file allows the structure to be maintained


### PR DESCRIPTION
## Summary
- expand cleanup staging list and ignore patterns
- document repo workspaces and scripts
- add TLS bypass fallback for Playwright scraper

## Testing
- `pnpm -r run typecheck`
- `pnpm -r run lint`
- `pnpm -r run build`
- `ruff check . --fix`
- `mypy .`
- `pytest -q`
- `(cd apps/api-go && go vet ./... && go test ./...)`
- `crates=$(git ls-files '**/Cargo.toml' | xargs -r -n1 dirname); if [ -n "$crates" ]; then for c in $crates; do (cd "$c" && cargo clippy -- -D warnings && cargo check); done; else echo "no rust crates"; fi`
- `pnpm -C apps/scraper-playwright run start || true` *(fails: browserContext.close: Protocol error)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7b4d858c833195f1001035195e40