### PR TITLE
Potential fix for code scanning alert no. 6: Shell command built from environment values

### DIFF
--- a/libs/js-core/build.cjs
+++ b/libs/js-core/build.cjs
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 
 // Function to get all .ts files recursively
 function getAllTsFiles(dir) {
@@ -40,7 +40,19 @@ tsFiles.forEach(file => {
   }
 
   try {
-    execSync(`npx tsc ${file} --outDir ${outputDir} --declaration --declarationMap --sourceMap --module ESNext --target ES2022 --moduleResolution node --esModuleInterop --skipLibCheck`, { stdio: 'inherit' });
+    execFileSync('npx', [
+      'tsc',
+      file,
+      '--outDir', outputDir,
+      '--declaration',
+      '--declarationMap',
+      '--sourceMap',
+      '--module', 'ESNext',
+      '--target', 'ES2022',
+      '--moduleResolution', 'node',
+      '--esModuleInterop',
+      '--skipLibCheck'
+    ], { stdio: 'inherit' });
     console.log(`Compiled ${file}`);
   } catch (error) {
     console.error(`Error compiling ${file}:`, error.message);


### PR DESCRIPTION
Potential fix for [https://github.com/BoxBoxmari/Project-Argus/security/code-scanning/6](https://github.com/BoxBoxmari/Project-Argus/security/code-scanning/6)

To fix the problem, avoid interpolating untrusted filenames or file paths directly into a shell command string used by `execSync`. Instead, call the equivalent command via `execFileSync`, passing the program and arguments as separate elements of an array. This ensures each argument is passed verbatim, without shell interpretation, thus safeguarding against spaces and shell metacharacters in file paths. Specifically, in libs/js-core/build.cjs, line 43 should be changed to use `execFileSync("npx", ["tsc", file, ...])` instead of `execSync`. This may require importing `execFileSync` from child_process in addition to (or instead of) `execSync`. Only the invocation on line 43 and possibly the import statement need to be altered.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
